### PR TITLE
Edited Typo in the status register block (x --> E)

### DIFF
--- a/doc/Cosmic Processor Specifications.md
+++ b/doc/Cosmic Processor Specifications.md
@@ -28,7 +28,7 @@
 
   ```
   7  bit  0
-  xxIP OCNZ
+  xEIP OCNZ
   |||| ||||
   |||| |||+-- (Z) Zero
   |||| ||+--- (N) Negative, high if result is negative


### PR DESCRIPTION
Hey, 
I found a typo (? - not sure if it was meant to be that way) in the `Cosmic Processor Specifications.md` file, in the part where the status register was described. The _Error_ flag was marked as `x` in the status register, implying it was not used. I changed it to `E`.